### PR TITLE
Error in default conf

### DIFF
--- a/mbslave.conf.default
+++ b/mbslave.conf.default
@@ -10,7 +10,6 @@ schema=musicbrainz
 base_url=http://ftp.musicbrainz.org/pub/musicbrainz/data/replication/
 
 [TABLES]
-ignore
 #ignore=tracklist_index
 
 [solr]


### PR DESCRIPTION
postgres@muzix:~/mbslave$ echo 'CREATE SCHEMA musicbrainz;' | ./mbslave-psql.py -S
Traceback (most recent call last):
  File "./mbslave-psql.py", line 12, in <module>
    config.read(os.path.dirname(**file**) + '/mbslave.conf')
  File "/usr/lib/python2.7/ConfigParser.py", line 297, in read
    self._read(fp, filename)
  File "/usr/lib/python2.7/ConfigParser.py", line 538, in _read
    raise e
ConfigParser.ParsingError: File contains parsing errors: ./mbslave.conf
    [line 13]: 'ignore\n'
