### PR TITLE
Update mbslave.conf.default

### DIFF
--- a/mbslave.conf.default
+++ b/mbslave.conf.default
@@ -10,6 +10,7 @@ schema=musicbrainz
 base_url=http://ftp.musicbrainz.org/pub/musicbrainz/data/replication/
 
 [TABLES]
+ignore=
 #ignore=tracklist_index
 
 [solr]


### PR DESCRIPTION
My mistake, otherwise you can change:

File "./mbslave-import.py", line 46, in <module>
    ignored_tables = set(config.get('TABLES', 'ignore').split(','))
