### PR TITLE
Explicitly denote Python 2 instead of just Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ user to user.
 
 ## Installation
 
- 0. Make sure you have [Python](http://python.org/) and [psycopg2](http://initd.org/psycopg/) installed.
+ 0. Make sure you have [Python 2](http://python.org/) and [psycopg2](http://initd.org/psycopg/) installed.
     On Debian and Ubuntu, that means installing these packages:
 
         sudo apt install python python-psycopg2

--- a/mbslave-import.py
+++ b/mbslave-import.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import tarfile
 import sys

--- a/mbslave-psql.py
+++ b/mbslave-psql.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 from optparse import OptionParser

--- a/mbslave-remap-schema.py
+++ b/mbslave-remap-schema.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import re
 import os

--- a/mbslave-solr-export.py
+++ b/mbslave-solr-export.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 from lxml import etree as ET

--- a/mbslave-solr-generate-triggers.py
+++ b/mbslave-solr-generate-triggers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 from mbslave import Config, connect_db

--- a/mbslave-solr-update.py
+++ b/mbslave-solr-update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import urllib2

--- a/mbslave-sync.py
+++ b/mbslave-sync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import tarfile
 import os


### PR DESCRIPTION
[PEP 394](https://www.python.org/dev/peps/pep-0394/) specifies that
> `python` should be used in the shebang line only for scripts that are source compatible with both Python 2 and 3.

mbslave does not currently work on Python 3, so should use `python2` on the shebang line.

The commit also changes the note in the README.md about requiring Python to specifying it to be "Python 2".